### PR TITLE
Update ompython.rst

### DIFF
--- a/UsersGuide/source/ompython.rst
+++ b/UsersGuide/source/ompython.rst
@@ -125,7 +125,7 @@ Full example:
   cmds = [
     "loadModel(Modelica)",
     "model test end test;",
-    'loadFile(getInstallationDirectoryPath() + "/share/doc/omc/testmodels/BouncingBall.mo")'
+    'loadFile(getInstallationDirectoryPath() + "/share/doc/omc/testmodels/BouncingBall.mo")',
     "getIconAnnotation(Modelica.Electrical.Analog.Basic.Resistor)",
     "getElementsInfo(Modelica.Electrical.Analog.Basic.Resistor)",
     "simulate(BouncingBall)",
@@ -133,7 +133,7 @@ Full example:
     ]
   for cmd in cmds:
     answer = omc.sendExpression(cmd)
-    print "\\nResult:\\n%s"%answer
+    print("\n{}:\n{}".format(cmd, answer))
 
 Implementation
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
There is a comma missing in the list of commands.
The next two commands still fail, but that is another issue.

This also updates the printing to use new style syntax as shown here:
https://pyformat.info/